### PR TITLE
flush output after print action

### DIFF
--- a/action.c
+++ b/action.c
@@ -440,6 +440,7 @@ a_print(char * opt[]) {
 	if(opt)
 		for(i=0; opt[i]; i++)
 			puts(opt[i]);
+	fflush(stdout);
 	return 0;
 }
 


### PR DESCRIPTION
Hi,

when using the print action to control another program and therefor pipe the output of dzen away, the output is buffered and therefore the actions appears to be executed later.

Explicit flushing the output after the print resolves that problem.

Thanks,
Alex
