### PR TITLE
Updated clickable areas (1 bugfix + clickable in slave window support)

### DIFF
--- a/README
+++ b/README
@@ -453,7 +453,7 @@ Interaction:
     ^ca(BTN, CMD) ... ^ca()      
 
                        Used to define 'clickable areas' anywhere inside the
-                       title window. 
+                       title window or slave window. 
                        - 'BTN' denotes the mouse button (1=left, 2=right, 3=middle, etc.) 
                        - 'CMD' denotes the command that should be spawned when the specific
                          area has been clicked with the defined button

--- a/draw.c
+++ b/draw.c
@@ -732,30 +732,34 @@ parse_line(const char *line, int lnr, int align, int reverse, int nodraw) {
 							font_was_set = 1;
 							break;
 						case ca:
-							if(lnr == -1) {
-								if(tval[0]) {
-									if(sens_areas_cnt < MAX_CLICKABLE_AREAS) {
-										get_sens_area(tval, 
-												&sens_areas[sens_areas_cnt].button, 
-												sens_areas[sens_areas_cnt].cmd);
-										sens_areas[sens_areas_cnt].start_x = px;
-										sens_areas[sens_areas_cnt].start_y = py;
-										sens_areas[sens_areas_cnt].end_y = py;
-										max_y = py;
-										sens_areas[sens_areas_cnt].window = LNR2WINDOW(lnr);
-										sens_areas[sens_areas_cnt].active = 0;
-										sens_areas_cnt++;
+							if(tval[0]) {
+								if(sens_areas_cnt < MAX_CLICKABLE_AREAS) {
+									get_sens_area(tval, 
+											&sens_areas[sens_areas_cnt].button, 
+											sens_areas[sens_areas_cnt].cmd);
+									sens_areas[sens_areas_cnt].start_x = px;
+									sens_areas[sens_areas_cnt].start_y = py;
+									sens_areas[sens_areas_cnt].end_y = py;
+									max_y = py;
+									sens_areas[sens_areas_cnt].topslave = LNR2WINDOW(lnr);
+									sens_areas[sens_areas_cnt].active = 0;
+									if(lnr == -1) {
+										sens_areas[sens_areas_cnt].win = dzen.title_win.win;
+									} else {
+										sens_areas[sens_areas_cnt].win = dzen.slave_win.line[lnr];
 									}
-								} else {
-										/* find most recent unclosed area */
-										for(i = sens_areas_cnt - 1; i >= 0; i--)
-											if(!sens_areas[i].active)
-												break;
-										if(i >= 0 && i < MAX_CLICKABLE_AREAS) {
-											sens_areas[i].end_x = px;
-											sens_areas[i].end_y = max_y;
-											sens_areas[i].active = 1;
-									}
+									sens_areas_cnt++;
+									
+								}
+							} else {
+									/* find most recent unclosed area */
+									for(i = sens_areas_cnt - 1; i >= 0; i--)
+										if(!sens_areas[i].active)
+											break;
+									if(i >= 0 && i < MAX_CLICKABLE_AREAS) {
+										sens_areas[i].end_x = px;
+										sens_areas[i].end_y = max_y;
+										sens_areas[i].active = 1;
 								}
 							}
 							break;

--- a/draw.c
+++ b/draw.c
@@ -420,8 +420,8 @@ parse_line(const char *line, int lnr, int align, int reverse, int nodraw) {
 	else {
 		h = dzen.font.height;
 		py = (dzen.line_height - h) / 2;
-        xorig[LNR2WINDOW(lnr)] = 0;
-
+		xorig[LNR2WINDOW(lnr)] = 0;
+		
 		if(lnr != -1) {
 			pm = XCreatePixmap(dzen.dpy, RootWindow(dzen.dpy, DefaultScreen(dzen.dpy)), dzen.slave_win.width,
 					dzen.line_height, DefaultDepth(dzen.dpy, dzen.screen));
@@ -429,7 +429,6 @@ parse_line(const char *line, int lnr, int align, int reverse, int nodraw) {
 		else {
 			pm = XCreatePixmap(dzen.dpy, RootWindow(dzen.dpy, DefaultScreen(dzen.dpy)), dzen.title_win.width,
 					dzen.line_height, DefaultDepth(dzen.dpy, dzen.screen));
-			sens_areas_cnt = 0;
 		}
 
 #ifdef DZEN_XFT
@@ -1015,6 +1014,7 @@ void
 drawbody(char * text) {
 	char *ec;
 	int i, write_buffer=1;
+	
 
 	if(dzen.slave_win.tcnt == -1) {
 		dzen.slave_win.tcnt = 0;

--- a/dzen.h
+++ b/dzen.h
@@ -68,11 +68,12 @@ typedef struct _CLICK_A {
 	int end_x;
 	int start_y;
 	int end_y;
+    int window;
 	char cmd[1024];
 } click_a;
 extern click_a sens_areas[MAX_CLICKABLE_AREAS];
 extern int sens_areas_cnt;
-extern int xorig;
+extern int xorig[2]; //0: top window, 1: slave window
 
 
 /* title window */

--- a/dzen.h
+++ b/dzen.h
@@ -23,6 +23,9 @@
 #define ALIGNLEFT   1
 #define ALIGNRIGHT  2
 
+#define TOPWINDOW   0
+#define SLAVEWINDOW 1
+
 #define MIN_BUF_SIZE   1024
 #define MAX_LINE_LEN   8192
 
@@ -68,13 +71,18 @@ typedef struct _CLICK_A {
 	int end_x;
 	int start_y;
 	int end_y;
-    int topslave;
 	Window win;		//(line)window to which the action is attached
 	char cmd[1024];
 } click_a;
-extern click_a sens_areas[MAX_CLICKABLE_AREAS];
-extern int sens_areas_cnt;
-extern int xorig[2]; //0: top window, 1: slave window
+
+typedef struct _SENS_PER_WINDOW {
+	click_a sens_areas[MAX_CLICKABLE_AREAS];
+	int sens_areas_cnt;
+} sens_w;
+
+//0: top window, 1: slave window
+extern int xorig[2];
+extern sens_w window_sens[2];
 
 
 /* title window */

--- a/dzen.h
+++ b/dzen.h
@@ -68,7 +68,8 @@ typedef struct _CLICK_A {
 	int end_x;
 	int start_y;
 	int end_y;
-    int window;
+    int topslave;
+	Window win;		//(line)window to which the action is attached
 	char cmd[1024];
 } click_a;
 extern click_a sens_areas[MAX_CLICKABLE_AREAS];

--- a/main.c
+++ b/main.c
@@ -705,8 +705,8 @@ handle_xev(void) {
              for(i=sens_areas_cnt; i>=0; i--) {
 				if(ev.xbutton.window == dzen.title_win.win &&
 						ev.xbutton.button == sens_areas[i].button &&
-						(ev.xbutton.x >=  sens_areas[i].start_x+xorig &&
-						ev.xbutton.x <=  sens_areas[i].end_x+xorig) &&
+						(ev.xbutton.x >=  sens_areas[i].start_x+xorig[sens_areas[i].window] &&
+						ev.xbutton.x <=  sens_areas[i].end_x+xorig[sens_areas[i].window]) &&
 						(ev.xbutton.y >=  sens_areas[i].start_y &&
 						ev.xbutton.y <=  sens_areas[i].end_y) &&
                         sens_areas[i].active) {

--- a/main.c
+++ b/main.c
@@ -27,9 +27,6 @@
 Dzen dzen = {0};
 static int last_cnt = 0;
 typedef void sigfunc(int);
-click_a sens_areas[MAX_CLICKABLE_AREAS];
-int sens_areas_cnt=0;
-
 
 static void
 clean_up(void) {
@@ -158,7 +155,6 @@ read_stdin(void) {
 	}
 	else {
 		while((n_off = chomp(buf, retbuf, n_off, n))) {
-			sens_areas_cnt = 0;
 			if(!dzen.slave_win.ishmenu
 					&& dzen.tsupdate
 					&& dzen.slave_win.max_lines
@@ -197,6 +193,8 @@ x_draw_body(void) {
 	dzen.y = 0;
 	dzen.w = dzen.slave_win.width;
 	dzen.h = dzen.line_height;
+	
+	window_sens[SLAVEWINDOW].sens_areas_cnt = 0;
 
 	if(!dzen.slave_win.last_line_vis) {
 		if(dzen.slave_win.tcnt < dzen.slave_win.max_lines) {
@@ -703,15 +701,17 @@ handle_xev(void) {
 			}
 
 			/* clickable areas */
-             for(i=sens_areas_cnt; i>=0; i--) {
-				if(ev.xbutton.window == sens_areas[i].win &&
-						ev.xbutton.button == sens_areas[i].button &&
-						(ev.xbutton.x >=  sens_areas[i].start_x+xorig[sens_areas[i].topslave] &&
-						ev.xbutton.x <=  sens_areas[i].end_x+xorig[sens_areas[i].topslave]) &&
-						(ev.xbutton.y >=  sens_areas[i].start_y &&
-						ev.xbutton.y <=  sens_areas[i].end_y) &&
-                        sens_areas[i].active) {
-					spawn(sens_areas[i].cmd);
+			int w_id = ev.xbutton.window == dzen.title_win.win ? 0 : 1;
+			sens_w w = window_sens[w_id];
+			for(i=w.sens_areas_cnt; i>=0; i--) {
+				if(ev.xbutton.window == w.sens_areas[i].win &&
+						ev.xbutton.button == w.sens_areas[i].button &&
+						(ev.xbutton.x >=  w.sens_areas[i].start_x+xorig[w_id] &&
+						ev.xbutton.x <=  w.sens_areas[i].end_x+xorig[w_id]) &&
+						(ev.xbutton.y >=  w.sens_areas[i].start_y &&
+						ev.xbutton.y <=  w.sens_areas[i].end_y) &&
+						w.sens_areas[i].active) {
+					spawn(w.sens_areas[i].cmd);
 					sa_clicked++;
 					break;
 				}

--- a/main.c
+++ b/main.c
@@ -703,10 +703,10 @@ handle_xev(void) {
 
 			/* clickable areas */
              for(i=sens_areas_cnt; i>=0; i--) {
-				if(ev.xbutton.window == dzen.title_win.win &&
+				if(ev.xbutton.window == sens_areas[i].win &&
 						ev.xbutton.button == sens_areas[i].button &&
-						(ev.xbutton.x >=  sens_areas[i].start_x+xorig[sens_areas[i].window] &&
-						ev.xbutton.x <=  sens_areas[i].end_x+xorig[sens_areas[i].window]) &&
+						(ev.xbutton.x >=  sens_areas[i].start_x+xorig[sens_areas[i].topslave] &&
+						ev.xbutton.x <=  sens_areas[i].end_x+xorig[sens_areas[i].topslave]) &&
 						(ev.xbutton.y >=  sens_areas[i].start_y &&
 						ev.xbutton.y <=  sens_areas[i].end_y) &&
                         sens_areas[i].active) {

--- a/main.c
+++ b/main.c
@@ -158,6 +158,7 @@ read_stdin(void) {
 	}
 	else {
 		while((n_off = chomp(buf, retbuf, n_off, n))) {
+			sens_areas_cnt = 0;
 			if(!dzen.slave_win.ishmenu
 					&& dzen.tsupdate
 					&& dzen.slave_win.max_lines


### PR DESCRIPTION
This pull request fixes a bug related to clickable areas, and adds clickable areas in the slave window.
- Bugfix: title bar clicks stopped working after the slave window gots an update.
  Example command:
  
  ``` bash
    (echo "^ca(1, echo click)Header^ca()"; while true; sleep 1; do echo test$((i++)); done) | ./dzen2 -l 12
  ```
  
  (The reason this happens is because `xorig` value is changed when the slave window got a redraw, but `xorig` is also used to determine whether a click happened on a clickable area).
- New feature: clickable areas in the slave window.
  
  Example code
  
  ``` bash
  (echo "^ca(1, echo TitleClick)Header^ca()"; while true; sleep 1; do echo "^ca(1, echo SlaveClick)test$((i++))^ca()"; done) | ./dzen2 -l 12
  ```
  
  For performance reasons, the clickable areas for the slave window and title window are separated. When one window gets an update, the clickable areas for that window only are re-calculated.
