### PR TITLE
Fix leak when switching XFT fonts

### DIFF
--- a/draw.c
+++ b/draw.c
@@ -155,6 +155,8 @@ setfont(const char *fontstr) {
 	}
 	dzen.font.height = dzen.font.ascent + dzen.font.descent;
 #else
+        if(dzen.font.xftfont)
+           XftFontClose(dzen.dpy, dzen.font.xftfont);
 	dzen.font.xftfont = XftFontOpenXlfd(dzen.dpy, dzen.screen, fontstr);
 	if(!dzen.font.xftfont)
 	   dzen.font.xftfont = XftFontOpenName(dzen.dpy, dzen.screen, fontstr);


### PR DESCRIPTION
Switching fonts on dzen's XFT builds using fn() command, causes
the old font to not get unloaded, hence slowly leaking memory.
