### PR TITLE
Fixing a buffer overflow error in chomp.

### DIFF
--- a/main.c
+++ b/main.c
@@ -109,8 +109,8 @@ chomp(char *inbuf, char *outbuf, int start, int len) {
 		rem = NULL;
 	}
 	while(off < len) {
-		if(i > MAX_LINE_LEN) {
-			outbuf[i] = '\0';
+		if(i >= MAX_LINE_LEN) {
+			outbuf[MAX_LINE_LEN-1] = '\0';
 			return ++off;
 		}
 		if(inbuf[off] != '\n') {


### PR DESCRIPTION
Fixes an a bug where dzen2 crashes if supplied with a line longer than MAX_LINE_LEN on STDIN.

Example:
perl -e 'print "A"x9000' | ./dzen2
