### PR TITLE
Add support for relative geometry

### DIFF
--- a/README
+++ b/README
@@ -59,7 +59,7 @@ dzen accepts a couple of options:
     -fn     font 
     -ta     alignement of title window content 
             l(eft), c(center), r(ight)
-    -tw     title window width
+    -tw     title window width (can be relative with %)
     -sa     alignment of slave window, see "-ta"
     -l      lines, see (1)
     -e      events and actions, see (2)
@@ -67,10 +67,10 @@ dzen accepts a couple of options:
     -u      update contents of title and 
             slave window simultaneously, see (4)
     -p      persist EOF (optional timeout in seconds)
-    -x      x position
-    -y      y position
-    -h      line height (default: fontheight + 2 pixels)
-    -w      width
+    -x      x position (can be relative with %)
+    -y      y position (can be relative with %)
+    -h      line height (default: fontheight + 2 pixels) (can be relative with %)
+    -w      width (can be relative with %)
     -xs     number of Xinerama screen
     -v      version information
 

--- a/README.dzen
+++ b/README.dzen
@@ -78,7 +78,7 @@ dzen accepts a couple of options:
     -fn     font 
     -ta     alignement of title window content 
             l(eft), c(center), r(ight)
-    -tw     title window width
+    -tw     title window width (can be relative with %)
     -sa     alignment of slave window, see "-ta"
     -l      lines,  ^fg(#6fbf47)see (1)
     -e      events and actions, ^fg(#6fbf47)see (2)
@@ -86,10 +86,10 @@ dzen accepts a couple of options:
     -u      update contents of title and 
             slave window simultaneously, ^fg(#6fbf47)see (4)
     -p      persist EOF (optional timeout in seconds)
-    -x      x position
-    -y      y position
-    -h      line height (default: fontheight + 2 pixels)
-    -w      width
+    -x      x position (can be relative with %)
+    -y      y position (can be relative with %)
+    -h      line height (default: fontheight + 2 pixels) (can be relative with %)
+    -w      width (can be relative with %)
     -xs     number of Xinerama screen
     -v      version information
 

--- a/config.mk
+++ b/config.mk
@@ -29,8 +29,8 @@ INCS = -I. -I/usr/include -I${X11INC}
 
 
 # Option 3: With Xinerama no XPM
-#LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 -lXinerama
-#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA
+LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 -lXinerama
+CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA
 
 
 ## Option 4: With Xinerama and XPM
@@ -39,8 +39,8 @@ INCS = -I. -I/usr/include -I${X11INC}
 
 
 ## Option 5: With XFT
-LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 `pkg-config --libs xft`
-CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XFT `pkg-config --cflags xft`
+# LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 `pkg-config --libs xft`
+# CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XFT `pkg-config --cflags xft`
 
 
 ## Option 6: With XPM and XFT

--- a/config.mk
+++ b/config.mk
@@ -29,8 +29,8 @@ INCS = -I. -I/usr/include -I${X11INC}
 
 
 # Option 3: With Xinerama no XPM
-LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 -lXinerama
-CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA
+#LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 -lXinerama
+#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA
 
 
 ## Option 4: With Xinerama and XPM
@@ -39,8 +39,8 @@ CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XINERAMA
 
 
 ## Option 5: With XFT
-#LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 `pkg-config --libs xft`
-#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XFT `pkg-config --cflags xft`
+LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 `pkg-config --libs xft`
+CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\" -DDZEN_XFT `pkg-config --cflags xft`
 
 
 ## Option 6: With XPM and XFT

--- a/dzen.h
+++ b/dzen.h
@@ -39,16 +39,29 @@
 # define Button7 7
 #endif
 
+#define RELATIVE_X 0x1
+#define RELATIVE_Y 0x2
+#define RELATIVE_WIDTH 0x4
+#define RELATIVE_HEIGHT 0x8
+#define RELATIVE_TITLE_WIDTH 0x10
+
 enum { ColFG, ColBG, ColLast };
 
 /* exapansion directions */
 enum { noexpand, left, right, both };
 
 typedef struct DZEN Dzen;
+typedef struct Geometry Geometry;
 typedef struct Fnt Fnt;
 typedef struct TW TWIN;
 typedef struct SW SWIN;
 typedef struct _Sline Sline;
+
+struct Geometry {
+	short x, y;
+	unsigned short title_width, width, height;
+	unsigned char relative_flags;
+};
 
 struct Fnt {
 	XFontStruct *xfont;


### PR DESCRIPTION
Currently, supporting a single dzen configuration across multiple computers can be a pain because the computers might have different display resolutions. This patch adds support for specifying the size and position of the dzen window relative to the resolution by specifying a percentage (e.g., `dzen -w 50%` will start a dzen window taking up half of the screen width-wise).
