### PR TITLE
Fix positioning with predefined constants

### DIFF
--- a/draw.c
+++ b/draw.c
@@ -642,11 +642,12 @@ parse_line(const char *line, int lnr, int align, int reverse, int nodraw) {
 									}
 								} else
 									set_posy=1;
-
-								if(r != 2)
-									px = px+n_posx<0? 0 : px + n_posx;
-								if(r != 1) 
-									py += n_posy;
+                                if (r != 5) {
+                                  if(r != 2)
+                                    px = px+n_posx<0? 0 : px + n_posx;
+                                  if(r != 1)
+                                    py += n_posy;
+                                }
 							} else {
 								set_posy = 0;
 								py = (dzen.line_height - dzen.font.height) / 2;


### PR DESCRIPTION
I am not sure if its completely correct. But it definitely step in the right direction, at least for predefined constants. Consider simple example ^p(_RIGHT) it will set px to dzen.width + 5!
